### PR TITLE
Windowless mod support

### DIFF
--- a/GenerateBonkLIB.js
+++ b/GenerateBonkLIB.js
@@ -78,8 +78,6 @@ Usable with:
 https://greasyfork.org/en/scripts/433861-code-injector-bonk-io
 */
 
-'use strict';
-
 // ! Compitable with Bonk Version 49
 window.bonkLIB = {};
 bonkLIB.version = "${packageJson.version}";

--- a/GenerateBonkLIB.js
+++ b/GenerateBonkLIB.js
@@ -77,6 +77,9 @@ const content = `// ==UserScript==
 Usable with:
 https://greasyfork.org/en/scripts/433861-code-injector-bonk-io
 */
+
+'use strict';
+
 // ! Compitable with Bonk Version 49
 window.bonkLIB = {};
 bonkLIB.version = "${packageJson.version}";

--- a/UserScript/BonkLIB.user.js
+++ b/UserScript/BonkLIB.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         BonkLIB
-// @version      1.1.1
+// @version      1.1.2
 // @author       FeiFei + Clarifi + BoZhi
 // @namespace    https://github.com/FeiFei-GH/BonkLIB
 // @description  BonkAPI + BonkHUD
@@ -13,9 +13,12 @@
 Usable with:
 https://greasyfork.org/en/scripts/433861-code-injector-bonk-io
 */
+
+'use strict';
+
 // ! Compitable with Bonk Version 49
 window.bonkLIB = {};
-bonkLIB.version = "1.1.1";
+bonkLIB.version = "1.1.2";
 
 window.bonkAPI = {};
 
@@ -63,6 +66,7 @@ bonkAPI.originalXMLSend = window.XMLHttpRequest.prototype.send;
 window.bonkHUD = {};
 
 bonkHUD.windowHold = [];
+bonkHUD.settingsHold = [];
 
 //! not used but will be
 // *Style Store
@@ -1847,10 +1851,9 @@ bonkAPI.receivePacket = function (packet) {
     }
 };
 bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
-    //! Currently not checking for repeating ids
+    //* leaving this for backwards compatability fr
     let id = "bonkHUD_window_" + windowName; 
     let modVersion = "1.0.0";
-    let settingElement = 0
     if(opts.hasOwnProperty("windowId")) {
         id = opts.windowId
     }
@@ -1869,9 +1872,6 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
             }
         }
     }
-    if(opts.hasOwnProperty("settingsContent")) {
-        settingElement = opts.settingsContent
-    }
     //! ignoring for now
     /*if(opts.hasOwnProperty("bonkVersion")) {
         
@@ -1883,11 +1883,16 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
     }
 
     //(name, id, recVersion, bodyHTML, settingElement = 0) {
+    let ind = bonkHUD.settingsHold.length;
+    bonkHUD.settingsHold.push({ id: id, settings: document.createElement("div") })
+    bonkHUD.windowHold[ind]({ id: id });
+    bonkHUD.windowHold[ind] = bonkHUD.getUISetting(ind)
 
-    let ind = bonkHUD.getWindowIndexByID(id);
-    if (ind == -1) {
-        bonkHUD.windowHold.push(bonkHUD.getUISetting(id));
-        ind = bonkHUD.windowHold.length - 1;
+    // Create Settings controller
+    bonkHUD.createMenuHeader(windowName, modVersion);
+    bonkHUD.createWindowControl(windowName, modVersion, ind);
+    if(opts.hasOwnProperty("settingsContent")) {
+        bonkHUD.createSettingsControl(windowName, modVersion, ind, settingElement);
     }
 
     // Create the main container 'dragItem'
@@ -1981,12 +1986,8 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
     windowContent.style.width = "calc(100% - 10px)";
     windowContent.style.height = "calc(100% - 42px)"; // Adjusted height for header
 
-    // Append the keyTable to the dragItem
+    // Append the content to the dragItem
     dragItem.appendChild(windowContent);
-
-    // Append the opacity control to the dragItem
-    let opacityControl = bonkHUD.createWindowControl(windowName, modVersion, ind, settingElement);
-    document.getElementById("bonkhud-window-settings-container").appendChild(opacityControl);
 
     // Append the dragItem to the body of the page
     document.body.appendChild(dragItem);
@@ -1996,11 +1997,11 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
         let visCheck = document.getElementById(id + "-visibility-check");
         visCheck.checked = false;
         bonkHUD.windowHold[ind].display = dragItem.style.display;
-        bonkHUD.saveUISetting(id);
+        bonkHUD.saveUISetting(ind);
     });
 
     // Add event listeners for dragging
-    dragItem.addEventListener('mousedown', (e) => bonkHUD.dragStart(e, dragItem));
+    dragItem.addEventListener('mousedown', (e) => bonkHUD.dragStart(e, dragItem, ind));
 
     // Add event listeners for resizing
     openCloseButton.addEventListener('mousedown', (e) => {
@@ -2014,16 +2015,53 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
             openCloseButton.innerText = "△";
         }
     });
-    dragNW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "nw"));
-    dragNE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "ne"));
-    dragSE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "se"));
-    dragSW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "sw"));
+    dragNW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "nw", ind));
+    dragNE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "ne", ind));
+    dragSE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "se", ind));
+    dragSW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "sw", ind));
 
     bonkHUD.updateStyleSettings(); //! probably slow but it works, its not like someone will have 100's of windows
 
-    return windowContent
+    return ind;
 };
-bonkHUD.dragStart = function (e, dragItem) {
+
+bonkHUD.createMod = function (modName, opts = {}) {
+    if(opts.hasOwnProperty("bonkLIBVersion")) {
+        if(opts.bonkLIBVersion != bonkLIB.version) {
+            if(typeof opts.bonkLIBVersion === 'string') {
+                if(opts.bonkLIBVersion.substring(0, opts.bonkLIBVersion.lastIndexOf(".")) != bonkLIB.version.substring(0, bonkLIB.version.lastIndexOf(".")))
+                    alert(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+                console.log(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+            }
+            else {
+                alert("Version is incompatible, please check with mod maker to fix");
+            }
+        }
+    }
+
+    if(opts.hasOwnProperty("noWindow") && opts.noWindow) {
+        let id = modName;
+        let modVersion = "1.0.0";
+        if(opts.hasOwnProperty("modVersion")) {
+            modVersion = opts.modVersion;
+        }
+
+        let ind = bonkHUD.settingsHold.length;
+        bonkHUD.settingsHold.push({ id: id, settings: document.createElement("div") })
+
+        // Create Settings controller
+        bonkHUD.createMenuHeader(modName, modVersion);
+        if(opts.hasOwnProperty("settingsContent")) {
+            bonkHUD.createSettingsControl(ind, settingElement);
+        }
+        return ind;
+    } else {
+        if(opts.hasOwnProperty("windowContent")) {
+            return bonkHUD.createWindow(modName, opts.windowContent, opts);
+        }
+    }
+};
+bonkHUD.dragStart = function (e, dragItem, ind) {
     bonkHUD.focusWindow(dragItem);
     // Prevents dragging from starting on the opacity slider
     if (e.target.classList.contains("bonkhud-drag-header") && !e.target.classList.contains("bonkhud-resize")) {
@@ -2033,7 +2071,7 @@ bonkHUD.dragStart = function (e, dragItem) {
         let startBottom = parseInt(window.getComputedStyle(dragItem).bottom, 10);
         const boundDragMove = bonkHUD.dragMove.bind(null, startX, startY, startRight, startBottom, dragItem);
         document.addEventListener('mousemove', boundDragMove);
-        document.addEventListener('mouseup', () => bonkHUD.dragEnd(boundDragMove, dragItem), { once: true });
+        document.addEventListener('mouseup', () => bonkHUD.dragEnd(boundDragMove, dragItem, ind), { once: true });
     }
 };
 
@@ -2046,25 +2084,24 @@ bonkHUD.dragMove = function (startX, startY, startRight, startBottom, dragItem, 
     dragItem.style.bottom = bonkHUD.pxTorem(moveY) + "rem";
 };
 
-bonkHUD.dragEnd = function (dragMoveFn, dragItem) {
+bonkHUD.dragEnd = function (dragMoveFn, dragItem, ind) {
     document.removeEventListener('mousemove', dragMoveFn);
-    let ind = bonkHUD.getWindowIndexByID(dragItem.id.substring(0, dragItem.id.length - 5));
     bonkHUD.windowHold[ind].width = dragItem.style.width;
     bonkHUD.windowHold[ind].height = dragItem.style.height;
     bonkHUD.windowHold[ind].bottom = dragItem.style.bottom;
     bonkHUD.windowHold[ind].right = dragItem.style.right;
-    bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+    bonkHUD.saveUISetting(ind);
 };
 // !Right now only useful for mods that have a setting that **only**
 // !needs to be read from 
 
-bonkHUD.saveModSetting = function (id, obj) {
-    let save_id = 'bonkHUD_Mod_Setting_' + id;
+bonkHUD.saveModSetting = function (ind, obj) {
+    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
     localStorage.setItem(save_id, JSON.stringify(obj));
 };
 
-bonkHUD.getModSetting = function (id) {
-    let save_id = 'bonkHUD_Mod_Setting_' + id;
+bonkHUD.getModSetting = function (ind) {
+    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
     let setting = JSON.parse(localStorage.getItem(save_id));
     if (!setting) {
         // !let mod maker handle it
@@ -2082,17 +2119,21 @@ bonkHUD.getModSetting = function (id) {
     }
 };*/
 
-bonkHUD.resetModSetting = function (id) {
+bonkHUD.resetModSetting = function (ind) {
     try {
-        let save_id = 'bonkHUD_Mod_Setting_' + id;
+        let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
         localStorage.removeItem(save_id);
         //Object.assign(windowElement.style, bonkHUD.getUISetting(id));
     } catch(er) {
-        console.log(`bonkHUD.resetModSetting: Settings for ${id} were not found.`);
+        console.log(`bonkHUD.resetModSetting: Settings for ${bonkHUD.settingsHold[ind].id} were not found.`);
     }
 };
+
+bonkHUD.createSettingsControl = function (ind, settingsElement) {
+    bonkHUD.settingsHold[ind].settings.appendChild(settingsElement);
+};
 // Function to start resizing the UI
-bonkHUD.startResizing = function (e, dragItem, dir) {
+bonkHUD.startResizing = function (e, dragItem, dir, ind) {
     e.stopPropagation(); // Prevent triggering dragStart for dragItem
 
     let startX = e.clientX;
@@ -2107,7 +2148,7 @@ bonkHUD.startResizing = function (e, dragItem, dir) {
     }
 
     function stopResizing() {
-        bonkHUD.resizeEnd(doResize, dragItem);
+        bonkHUD.resizeEnd(doResize, dragItem, ind);
     }
 
     document.addEventListener('mousemove', doResize);
@@ -2146,14 +2187,14 @@ bonkHUD.resizeMove = function (e, startX, startY, windowX, windowY, startWidth, 
 };
 
 // Function to stop the resize event
-bonkHUD.resizeEnd = function (resizeMoveFn, dragItem, dir) {
+bonkHUD.resizeEnd = function (resizeMoveFn, dragItem, ind) {
     document.removeEventListener('mousemove', resizeMoveFn);
     let ind = bonkHUD.getWindowIndexByID(dragItem.id.substring(0, dragItem.id.length - 5));
     bonkHUD.windowHold[ind].width = dragItem.style.width;
     bonkHUD.windowHold[ind].height = dragItem.style.height;
     bonkHUD.windowHold[ind].bottom = dragItem.style.bottom;
     bonkHUD.windowHold[ind].right = dragItem.style.right;
-    bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+    bonkHUD.saveUISetting(ind);
 };
 bonkHUD.saveStyleSettings = function () {
     localStorage.setItem('bonkHUD_Style_Settings', JSON.stringify(bonkHUD.styleHold));
@@ -2266,18 +2307,17 @@ bonkHUD.updateStyleSettings = function () {
         }
     }
 };
-bonkHUD.saveUISetting = function (id) {
-    let ind = bonkHUD.getWindowIndexByID(id);
-    let save_id = 'bonkHUD_Setting_' + id;
+bonkHUD.saveUISetting = function (ind) {
+    let save_id = 'bonkHUD_Setting_' + bonkHUD.windowHold[ind].id;
     localStorage.setItem(save_id, JSON.stringify(bonkHUD.windowHold[ind]));
 };
 
-bonkHUD.getUISetting = function (id) {
-    let save_id = 'bonkHUD_Setting_' + id;
+bonkHUD.getUISetting = function (ind) {
+    let save_id = 'bonkHUD_Setting_' + bonkHUD.windowHold[ind].id;
     let setting = JSON.parse(localStorage.getItem(save_id));
     if (!setting) {
         setting = {
-            id: id,
+            id: bonkHUD.windowHold[ind].id,
             width: "154px",
             height: "100px",
             bottom: "0rem",
@@ -2289,23 +2329,23 @@ bonkHUD.getUISetting = function (id) {
     return setting;
 };
 
-bonkHUD.loadUISetting = function (id) {
-    let windowElement = document.getElementById(id + "-drag");
+bonkHUD.loadUISetting = function (ind) {
+    let windowElement = document.getElementById(bonkHUD.windowHold[ind].id + "-drag");
     if (windowElement) {
-        Object.assign(windowElement.style, bonkHUD.getUISetting(id));
+        Object.assign(windowElement.style, bonkHUD.getUISetting(ind));
     } else {
-        console.log(`bonkHUD.loadUISetting: Window element not found for id: ${id}. Please ensure the window has been created.`);
+        console.log(`bonkHUD.loadUISetting: Window element not found for id: ${bonkHUD.windowHold[ind].id}. Please ensure the window has been created.`);
     }
 };
 
-bonkHUD.resetUISetting = function (id) {
-    let windowElement = document.getElementById(id + "-drag");
+bonkHUD.resetUISetting = function (ind) {
+    let windowElement = document.getElementById(bonkHUD.windowHold[ind].id + "-drag");
     if (windowElement) {
-        let save_id = 'bonkHUD_Setting_' + id;
+        let save_id = 'bonkHUD_Setting_' + bonkHUD.windowHold[ind].id;
         localStorage.removeItem(save_id);
-        Object.assign(windowElement.style, bonkHUD.getUISetting(id));
+        Object.assign(windowElement.style, bonkHUD.getUISetting(ind));
     } else {
-        console.log(`bonkHUD.resetUISetting: Window element not found for id: ${id}. Please ensure the window has been created.`);
+        console.log(`bonkHUD.resetUISetting: Window element not found for id: ${bonkHUD.windowHold[ind].id}. Please ensure the window has been created.`);
     }
 };
 bonkHUD.getWindowIndexByID = function (id) {
@@ -2354,6 +2394,13 @@ bonkHUD.generateButton = function (name) {
         e.target.style.backgroundColor = bonkHUD.styleHold.buttonColor.color;
     });
     return newButton;
+}
+
+bonkHUD.generateSection = function () {
+    let sliderRow = document.createElement("div");
+    sliderRow.classList.add("bonkhud-settings-row");
+    sliderRow.classList.add("bonkhud-border-color");
+    return sliderRow;
 }
 bonkHUD.initialize = function () {
     //bonkHUD.stylesheet = document.createElement("style");
@@ -2604,11 +2651,9 @@ bonkHUD.initialize = function () {
         styleImportInput.click();
     });
 };
-bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement = 0) {
+bonkHUD.createMenuHeader = function (name, recVersion) {
     // Create container for the opacity controls with initial styles
-    let sliderRow = document.createElement("div");
-    sliderRow.classList.add("bonkhud-settings-row");
-    sliderRow.classList.add("bonkhud-border-color");
+    let sliderRow = bonkHUD.generateSection();
 
     // Add a title to the slider row for visual clarity
     let sliderTitle = document.createElement("div");
@@ -2617,6 +2662,12 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
     sliderTitle.style.fontSize = "1.2rem"; // Text size for readability
     sliderTitle.style.fontWeight = "bold"; // Make the title text bold
     sliderRow.appendChild(sliderTitle); // Insert the title into the slider container
+
+    document.getElementById("bonkhud-window-settings-container").appendChild(sliderRow);
+}
+
+bonkHUD.createWindowControl = function (ind) {
+    let sliderRow = bonkHUD.generateSection();
 
     let holdLeft = document.createElement("div");
     holdLeft.style.display = "flex";
@@ -2641,7 +2692,7 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
         let control = document.getElementById(bonkHUD.windowHold[ind].id + "-drag"); // Update the UI opacity in real-time;
         control.style.opacity = this.value;
         bonkHUD.windowHold[ind].opacity = control.style.opacity;
-        bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+        bonkHUD.saveUISetting(ind);
     };
     holdLeft.appendChild(opacitySlider); // Place the slider into the slider container
 
@@ -2669,7 +2720,7 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
         let control = document.getElementById(bonkHUD.windowHold[ind].id + "-drag"); // Update the UI opacity in real-time;
         control.style.display = this.checked ? "block" : "none";
         bonkHUD.windowHold[ind].display = control.style.display;
-        bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+        bonkHUD.saveUISetting(ind);
     };
     holdRight.appendChild(visiblityCheck); // Place the slider into the slider container
 
@@ -2678,20 +2729,15 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
     windowResetButton.style.paddingRight = "5px";
     windowResetButton.style.display = "inline-block";
     windowResetButton.addEventListener('click', (e) => {
-        bonkHUD.resetUISetting(bonkHUD.windowHold[ind].id);
-        bonkHUD.loadUISetting(bonkHUD.windowHold[ind].id);
+        bonkHUD.resetUISetting(ind);
+        bonkHUD.loadUISetting(ind);
     });
 
     sliderRow.appendChild(holdLeft);
     sliderRow.appendChild(holdRight);
     sliderRow.appendChild(windowResetButton);
 
-    //! may instead make it so when sliderrow is focused, the
-    //! seetings appear on the big settings menu
-    if(settingsElement !== 0 && settingsElement instanceof Node)
-        sliderRow.appendChild(settingsElement);
-
-    return sliderRow; // Return the fully constructed slider row element
+    bonkHUD.settingsHold[ind].settings.appendChild(sliderRow);
 };
 
 bonkHUD.focusWindow = function (focusItem) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bonklib",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bonklib",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "license": "MIT",
             "dependencies": {
                 "bonklib": "file:",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bonklib",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bonklib",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "license": "MIT",
             "dependencies": {
                 "bonklib": "file:",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bonklib",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "BonkLIB",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bonklib",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "BonkLIB",
     "main": "index.js",
     "scripts": {

--- a/src/BonkHUD/createWindow.js
+++ b/src/BonkHUD/createWindow.js
@@ -210,4 +210,4 @@ bonkHUD.createMod = function (modName, opts = {}) {
             return bonkHUD.createWindow(modName, opts.windowContent, opts);
         }
     }
-}
+};

--- a/src/BonkHUD/createWindow.js
+++ b/src/BonkHUD/createWindow.js
@@ -1,9 +1,9 @@
 //@Main{Preload}
 
 bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
+    //* leaving this for backwards compatability fr
     let id = "bonkHUD_window_" + windowName; 
     let modVersion = "1.0.0";
-    let settingElement = 0
     if(opts.hasOwnProperty("windowId")) {
         id = opts.windowId
     }
@@ -22,9 +22,6 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
             }
         }
     }
-    if(opts.hasOwnProperty("settingsContent")) {
-        settingElement = opts.settingsContent
-    }
     //! ignoring for now
     /*if(opts.hasOwnProperty("bonkVersion")) {
         
@@ -36,11 +33,16 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
     }
 
     //(name, id, recVersion, bodyHTML, settingElement = 0) {
+    let ind = bonkHUD.settingsHold.length;
+    bonkHUD.settingsHold.push({ id: id, settings: document.createElement("div") })
+    bonkHUD.windowHold[ind]({ id: id });
+    bonkHUD.windowHold[ind] = bonkHUD.getUISetting(ind)
 
-    let ind = bonkHUD.getWindowIndexByID(id);
-    if (ind == -1) {
-        ind = bonkHUD.windowHold.length;
-        bonkHUD.windowHold.push(bonkHUD.getUISetting(ind));
+    // Create Settings controller
+    bonkHUD.createMenuHeader(windowName, modVersion);
+    bonkHUD.createWindowControl(windowName, modVersion, ind);
+    if(opts.hasOwnProperty("settingsContent")) {
+        bonkHUD.createSettingsControl(windowName, modVersion, ind, settingElement);
     }
 
     // Create the main container 'dragItem'
@@ -134,12 +136,8 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
     windowContent.style.width = "calc(100% - 10px)";
     windowContent.style.height = "calc(100% - 42px)"; // Adjusted height for header
 
-    // Append the keyTable to the dragItem
+    // Append the content to the dragItem
     dragItem.appendChild(windowContent);
-
-    // Append the opacity control to the dragItem
-    let opacityControl = bonkHUD.createWindowControl(windowName, modVersion, ind, settingElement);
-    document.getElementById("bonkhud-window-settings-container").appendChild(opacityControl);
 
     // Append the dragItem to the body of the page
     document.body.appendChild(dragItem);
@@ -174,5 +172,42 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
 
     bonkHUD.updateStyleSettings(); //! probably slow but it works, its not like someone will have 100's of windows
 
-    return windowContent
+    return ind;
 };
+
+bonkHUD.createMod = function (modName, opts = {}) {
+    if(opts.hasOwnProperty("bonkLIBVersion")) {
+        if(opts.bonkLIBVersion != bonkLIB.version) {
+            if(typeof opts.bonkLIBVersion === 'string') {
+                if(opts.bonkLIBVersion.substring(0, opts.bonkLIBVersion.lastIndexOf(".")) != bonkLIB.version.substring(0, bonkLIB.version.lastIndexOf(".")))
+                    alert(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+                console.log(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+            }
+            else {
+                alert("Version is incompatible, please check with mod maker to fix");
+            }
+        }
+    }
+
+    if(opts.hasOwnProperty("noWindow") && opts.noWindow) {
+        let id = modName;
+        let modVersion = "1.0.0";
+        if(opts.hasOwnProperty("modVersion")) {
+            modVersion = opts.modVersion;
+        }
+
+        let ind = bonkHUD.settingsHold.length;
+        bonkHUD.settingsHold.push({ id: id, settings: document.createElement("div") })
+
+        // Create Settings controller
+        bonkHUD.createMenuHeader(modName, modVersion);
+        if(opts.hasOwnProperty("settingsContent")) {
+            bonkHUD.createSettingsControl(ind, settingElement);
+        }
+        return ind;
+    } else {
+        if(opts.hasOwnProperty("windowContent")) {
+            return bonkHUD.createWindow(modName, opts.windowContent, opts);
+        }
+    }
+}

--- a/src/BonkHUD/createWindow.js
+++ b/src/BonkHUD/createWindow.js
@@ -1,7 +1,6 @@
 //@Main{Preload}
 
 bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
-    //! Currently not checking for repeating ids
     let id = "bonkHUD_window_" + windowName; 
     let modVersion = "1.0.0";
     let settingElement = 0
@@ -150,11 +149,11 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
         let visCheck = document.getElementById(id + "-visibility-check");
         visCheck.checked = false;
         bonkHUD.windowHold[ind].display = dragItem.style.display;
-        bonkHUD.saveUISetting(id);
+        bonkHUD.saveUISetting(ind);
     });
 
     // Add event listeners for dragging
-    dragItem.addEventListener('mousedown', (e) => bonkHUD.dragStart(e, dragItem));
+    dragItem.addEventListener('mousedown', (e) => bonkHUD.dragStart(e, dragItem, ind));
 
     // Add event listeners for resizing
     openCloseButton.addEventListener('mousedown', (e) => {
@@ -168,10 +167,10 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
             openCloseButton.innerText = "△";
         }
     });
-    dragNW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "nw"));
-    dragNE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "ne"));
-    dragSE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "se"));
-    dragSW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "sw"));
+    dragNW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "nw", ind));
+    dragNE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "ne", ind));
+    dragSE.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "se", ind));
+    dragSW.addEventListener('mousedown', (e) => bonkHUD.startResizing(e, dragItem, "sw", ind));
 
     bonkHUD.updateStyleSettings(); //! probably slow but it works, its not like someone will have 100's of windows
 

--- a/src/BonkHUD/createWindow.js
+++ b/src/BonkHUD/createWindow.js
@@ -39,8 +39,8 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
 
     let ind = bonkHUD.getWindowIndexByID(id);
     if (ind == -1) {
-        bonkHUD.windowHold.push(bonkHUD.getUISetting(id));
-        ind = bonkHUD.windowHold.length - 1;
+        ind = bonkHUD.windowHold.length;
+        bonkHUD.windowHold.push(bonkHUD.getUISetting(ind));
     }
 
     // Create the main container 'dragItem'

--- a/src/BonkHUD/createWindow.js
+++ b/src/BonkHUD/createWindow.js
@@ -34,17 +34,19 @@ bonkHUD.createWindow = function (windowName, windowContent, opts = {}) {
 
     //(name, id, recVersion, bodyHTML, settingElement = 0) {
     let ind = bonkHUD.settingsHold.length;
-    bonkHUD.settingsHold.push({ id: id, settings: document.createElement("div") })
-    bonkHUD.windowHold[ind]({ id: id });
+    bonkHUD.settingsHold.push(id)
+    bonkHUD.windowHold[ind] = { id: id };
     bonkHUD.windowHold[ind] = bonkHUD.getUISetting(ind)
 
     // Create Settings controller
-    bonkHUD.createMenuHeader(windowName, modVersion);
-    bonkHUD.createWindowControl(windowName, modVersion, ind);
+    let fullSettingsDiv = document.createElement("div");
+    bonkHUD.createWindowControl(ind, fullSettingsDiv);
     if(opts.hasOwnProperty("settingsContent")) {
-        bonkHUD.createSettingsControl(windowName, modVersion, ind, settingElement);
+        bonkHUD.createSettingsControl(opts.settingsContent, fullSettingsDiv);
     }
+    bonkHUD.createMenuHeader(windowName, fullSettingsDiv, modVersion);
 
+    //! POSSIBLY MOVE EVERYTHING ABOVE TO createMod TO MAKE CLEANER BUT NOT BACKWARDS COMPATIBLE
     // Create the main container 'dragItem'
     let dragItem = document.createElement("div");
     dragItem.classList.add("bonkhud-window-container");
@@ -197,13 +199,14 @@ bonkHUD.createMod = function (modName, opts = {}) {
         }
 
         let ind = bonkHUD.settingsHold.length;
-        bonkHUD.settingsHold.push({ id: id, settings: document.createElement("div") })
+        bonkHUD.settingsHold.push(id)
 
         // Create Settings controller
-        bonkHUD.createMenuHeader(modName, modVersion);
+        let fullSettingsDiv = document.createElement("div");
         if(opts.hasOwnProperty("settingsContent")) {
-            bonkHUD.createSettingsControl(ind, settingElement);
+            bonkHUD.createSettingsControl(opts.settingsContent, fullSettingsDiv);
         }
+        bonkHUD.createMenuHeader(modName, fullSettingsDiv, modVersion);
         return ind;
     } else {
         if(opts.hasOwnProperty("windowContent")) {

--- a/src/BonkHUD/handleDrag.js
+++ b/src/BonkHUD/handleDrag.js
@@ -1,6 +1,6 @@
 //@Main{Preload}
 
-bonkHUD.dragStart = function (e, dragItem) {
+bonkHUD.dragStart = function (e, dragItem, ind) {
     bonkHUD.focusWindow(dragItem);
     // Prevents dragging from starting on the opacity slider
     if (e.target.classList.contains("bonkhud-drag-header") && !e.target.classList.contains("bonkhud-resize")) {
@@ -10,7 +10,7 @@ bonkHUD.dragStart = function (e, dragItem) {
         let startBottom = parseInt(window.getComputedStyle(dragItem).bottom, 10);
         const boundDragMove = bonkHUD.dragMove.bind(null, startX, startY, startRight, startBottom, dragItem);
         document.addEventListener('mousemove', boundDragMove);
-        document.addEventListener('mouseup', () => bonkHUD.dragEnd(boundDragMove, dragItem), { once: true });
+        document.addEventListener('mouseup', () => bonkHUD.dragEnd(boundDragMove, dragItem, ind), { once: true });
     }
 };
 
@@ -23,12 +23,11 @@ bonkHUD.dragMove = function (startX, startY, startRight, startBottom, dragItem, 
     dragItem.style.bottom = bonkHUD.pxTorem(moveY) + "rem";
 };
 
-bonkHUD.dragEnd = function (dragMoveFn, dragItem) {
+bonkHUD.dragEnd = function (dragMoveFn, dragItem, ind) {
     document.removeEventListener('mousemove', dragMoveFn);
-    let ind = bonkHUD.getWindowIndexByID(dragItem.id.substring(0, dragItem.id.length - 5));
     bonkHUD.windowHold[ind].width = dragItem.style.width;
     bonkHUD.windowHold[ind].height = dragItem.style.height;
     bonkHUD.windowHold[ind].bottom = dragItem.style.bottom;
     bonkHUD.windowHold[ind].right = dragItem.style.right;
-    bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+    bonkHUD.saveUISetting(ind);
 };

--- a/src/BonkHUD/handleModSettings.js
+++ b/src/BonkHUD/handleModSettings.js
@@ -3,13 +3,13 @@
 // !Right now only useful for mods that have a setting that **only**
 // !needs to be read from 
 
-bonkHUD.saveModSetting = function (id, obj) {
-    let save_id = 'bonkHUD_Mod_Setting_' + id;
+bonkHUD.saveModSetting = function (ind, obj) {
+    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
     localStorage.setItem(save_id, JSON.stringify(obj));
 };
 
-bonkHUD.getModSetting = function (id) {
-    let save_id = 'bonkHUD_Mod_Setting_' + id;
+bonkHUD.getModSetting = function (ind) {
+    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
     let setting = JSON.parse(localStorage.getItem(save_id));
     if (!setting) {
         // !let mod maker handle it
@@ -27,12 +27,16 @@ bonkHUD.getModSetting = function (id) {
     }
 };*/
 
-bonkHUD.resetModSetting = function (id) {
+bonkHUD.resetModSetting = function (ind) {
     try {
-        let save_id = 'bonkHUD_Mod_Setting_' + id;
+        let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
         localStorage.removeItem(save_id);
         //Object.assign(windowElement.style, bonkHUD.getUISetting(id));
     } catch(er) {
-        console.log(`bonkHUD.resetModSetting: Settings for ${id} were not found.`);
+        console.log(`bonkHUD.resetModSetting: Settings for ${bonkHUD.settingsHold[ind].id} were not found.`);
     }
 };
+
+bonkHUD.createSettingsControl = function (ind, settingsElement) {
+    bonkHUD.settingsHold[ind].settings.appendChild(settingsElement);
+}

--- a/src/BonkHUD/handleModSettings.js
+++ b/src/BonkHUD/handleModSettings.js
@@ -4,12 +4,12 @@
 // !needs to be read from 
 
 bonkHUD.saveModSetting = function (ind, obj) {
-    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
+    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind];
     localStorage.setItem(save_id, JSON.stringify(obj));
 };
 
 bonkHUD.getModSetting = function (ind) {
-    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
+    let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind];
     let setting = JSON.parse(localStorage.getItem(save_id));
     if (!setting) {
         // !let mod maker handle it
@@ -29,14 +29,15 @@ bonkHUD.getModSetting = function (ind) {
 
 bonkHUD.resetModSetting = function (ind) {
     try {
-        let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind].id;
+        let save_id = 'bonkHUD_Mod_Setting_' + bonkHUD.settingsHold[ind];
         localStorage.removeItem(save_id);
         //Object.assign(windowElement.style, bonkHUD.getUISetting(id));
     } catch(er) {
-        console.log(`bonkHUD.resetModSetting: Settings for ${bonkHUD.settingsHold[ind].id} were not found.`);
+        console.log(`bonkHUD.resetModSetting: Settings for ${bonkHUD.settingsHold[ind]} were not found.`);
     }
 };
 
-bonkHUD.createSettingsControl = function (ind, settingsElement) {
-    bonkHUD.settingsHold[ind].settings.appendChild(settingsElement);
+bonkHUD.createSettingsControl = function (settingsElement, element) {
+    element.appendChild(settingsElement)
+    //bonkHUD.settingsHold[ind].settings.appendChild(settingsElement);
 };

--- a/src/BonkHUD/handleModSettings.js
+++ b/src/BonkHUD/handleModSettings.js
@@ -39,4 +39,4 @@ bonkHUD.resetModSetting = function (ind) {
 
 bonkHUD.createSettingsControl = function (ind, settingsElement) {
     bonkHUD.settingsHold[ind].settings.appendChild(settingsElement);
-}
+};

--- a/src/BonkHUD/handleResize.js
+++ b/src/BonkHUD/handleResize.js
@@ -1,7 +1,7 @@
 //@Main{Preload}
 
 // Function to start resizing the UI
-bonkHUD.startResizing = function (e, dragItem, dir) {
+bonkHUD.startResizing = function (e, dragItem, dir, ind) {
     e.stopPropagation(); // Prevent triggering dragStart for dragItem
 
     let startX = e.clientX;
@@ -16,7 +16,7 @@ bonkHUD.startResizing = function (e, dragItem, dir) {
     }
 
     function stopResizing() {
-        bonkHUD.resizeEnd(doResize, dragItem);
+        bonkHUD.resizeEnd(doResize, dragItem, ind);
     }
 
     document.addEventListener('mousemove', doResize);
@@ -55,12 +55,12 @@ bonkHUD.resizeMove = function (e, startX, startY, windowX, windowY, startWidth, 
 };
 
 // Function to stop the resize event
-bonkHUD.resizeEnd = function (resizeMoveFn, dragItem, dir) {
+bonkHUD.resizeEnd = function (resizeMoveFn, dragItem, ind) {
     document.removeEventListener('mousemove', resizeMoveFn);
     let ind = bonkHUD.getWindowIndexByID(dragItem.id.substring(0, dragItem.id.length - 5));
     bonkHUD.windowHold[ind].width = dragItem.style.width;
     bonkHUD.windowHold[ind].height = dragItem.style.height;
     bonkHUD.windowHold[ind].bottom = dragItem.style.bottom;
     bonkHUD.windowHold[ind].right = dragItem.style.right;
-    bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+    bonkHUD.saveUISetting(ind);
 };

--- a/src/BonkHUD/handleResize.js
+++ b/src/BonkHUD/handleResize.js
@@ -57,7 +57,7 @@ bonkHUD.resizeMove = function (e, startX, startY, windowX, windowY, startWidth, 
 // Function to stop the resize event
 bonkHUD.resizeEnd = function (resizeMoveFn, dragItem, ind) {
     document.removeEventListener('mousemove', resizeMoveFn);
-    let ind = bonkHUD.getWindowIndexByID(dragItem.id.substring(0, dragItem.id.length - 5));
+    //let ind = bonkHUD.getWindowIndexByID(dragItem.id.substring(0, dragItem.id.length - 5));
     bonkHUD.windowHold[ind].width = dragItem.style.width;
     bonkHUD.windowHold[ind].height = dragItem.style.height;
     bonkHUD.windowHold[ind].bottom = dragItem.style.bottom;

--- a/src/BonkHUD/handleStyleSettings.js
+++ b/src/BonkHUD/handleStyleSettings.js
@@ -97,14 +97,14 @@ bonkHUD.updateStyleSettings = function () {
         if(prop == "buttonColorHover")
             continue;
         else if(prop == "headerColor") {
-            elements = document.getElementsByClassName(bonkHUD.styleHold[prop].class);
+            let elements = document.getElementsByClassName(bonkHUD.styleHold[prop].class);
             for (let j = 0; j < elements.length; j++) {
                 elements[j].style.setProperty(bonkHUD.styleHold[prop].css, bonkHUD.styleHold[prop].color, "important");
             }
             continue;
         }
         else {
-            elements = document.getElementsByClassName(bonkHUD.styleHold[prop].class);
+            let elements = document.getElementsByClassName(bonkHUD.styleHold[prop].class);
             for (let j = 0; j < elements.length; j++) {
                 elements[j].style.setProperty(bonkHUD.styleHold[prop].css, bonkHUD.styleHold[prop].color);
             }

--- a/src/BonkHUD/handleUISettings.js
+++ b/src/BonkHUD/handleUISettings.js
@@ -1,8 +1,7 @@
 //@Main{Preload}
 
-bonkHUD.saveUISetting = function (id) {
-    let ind = bonkHUD.getWindowIndexByID(id);
-    let save_id = 'bonkHUD_Setting_' + id;
+bonkHUD.saveUISetting = function (ind) {
+    let save_id = 'bonkHUD_Setting_' + bonkHUD.windowHold[ind].id;
     localStorage.setItem(save_id, JSON.stringify(bonkHUD.windowHold[ind]));
 };
 

--- a/src/BonkHUD/handleUISettings.js
+++ b/src/BonkHUD/handleUISettings.js
@@ -5,12 +5,12 @@ bonkHUD.saveUISetting = function (ind) {
     localStorage.setItem(save_id, JSON.stringify(bonkHUD.windowHold[ind]));
 };
 
-bonkHUD.getUISetting = function (id) {
-    let save_id = 'bonkHUD_Setting_' + id;
+bonkHUD.getUISetting = function (ind) {
+    let save_id = 'bonkHUD_Setting_' + bonkHUD.windowHold[ind].id;
     let setting = JSON.parse(localStorage.getItem(save_id));
     if (!setting) {
         setting = {
-            id: id,
+            id: bonkHUD.windowHold[ind].id,
             width: "154px",
             height: "100px",
             bottom: "0rem",
@@ -22,22 +22,22 @@ bonkHUD.getUISetting = function (id) {
     return setting;
 };
 
-bonkHUD.loadUISetting = function (id) {
-    let windowElement = document.getElementById(id + "-drag");
+bonkHUD.loadUISetting = function (ind) {
+    let windowElement = document.getElementById(bonkHUD.windowHold[ind].id + "-drag");
     if (windowElement) {
-        Object.assign(windowElement.style, bonkHUD.getUISetting(id));
+        Object.assign(windowElement.style, bonkHUD.getUISetting(ind));
     } else {
-        console.log(`bonkHUD.loadUISetting: Window element not found for id: ${id}. Please ensure the window has been created.`);
+        console.log(`bonkHUD.loadUISetting: Window element not found for id: ${bonkHUD.windowHold[ind].id}. Please ensure the window has been created.`);
     }
 };
 
-bonkHUD.resetUISetting = function (id) {
-    let windowElement = document.getElementById(id + "-drag");
+bonkHUD.resetUISetting = function (ind) {
+    let windowElement = document.getElementById(bonkHUD.windowHold[ind].id + "-drag");
     if (windowElement) {
-        let save_id = 'bonkHUD_Setting_' + id;
+        let save_id = 'bonkHUD_Setting_' + bonkHUD.windowHold[ind].id;
         localStorage.removeItem(save_id);
-        Object.assign(windowElement.style, bonkHUD.getUISetting(id));
+        Object.assign(windowElement.style, bonkHUD.getUISetting(ind));
     } else {
-        console.log(`bonkHUD.resetUISetting: Window element not found for id: ${id}. Please ensure the window has been created.`);
+        console.log(`bonkHUD.resetUISetting: Window element not found for id: ${bonkHUD.windowHold[ind].id}. Please ensure the window has been created.`);
     }
 };

--- a/src/BonkHUD/helperMethods.js
+++ b/src/BonkHUD/helperMethods.js
@@ -1,5 +1,6 @@
 //@Main{Preload}
 
+//! Eventually change ID to Id
 bonkHUD.getWindowIndexByID = function (id) {
     for (let i = 0; i < bonkHUD.windowHold.length; i++) {
         if (bonkHUD.windowHold[i].id == id) {
@@ -8,6 +9,14 @@ bonkHUD.getWindowIndexByID = function (id) {
     }
     return -1;
 };
+
+bonkHUD.getWindowIdByIndex = function (ind) {
+    return bonkHUD.windowHold[ind].id
+}
+
+bonkHUD.getElementByIndex = function (ind) {
+    return document.getElementById(bonkHUD.windowHold[ind].id)
+}
 
 bonkHUD.clamp = function (val, min, max) {
     //? supposedly faster than Math.max/min

--- a/src/BonkHUD/hudGenerators.js
+++ b/src/BonkHUD/hudGenerators.js
@@ -18,3 +18,10 @@ bonkHUD.generateButton = function (name) {
     });
     return newButton;
 }
+
+bonkHUD.generateSection = function () {
+    let sliderRow = document.createElement("div");
+    sliderRow.classList.add("bonkhud-settings-row");
+    sliderRow.classList.add("bonkhud-border-color");
+    return sliderRow;
+}

--- a/src/BonkHUD/initializeHUD.js
+++ b/src/BonkHUD/initializeHUD.js
@@ -55,7 +55,7 @@ bonkHUD.initialize = function () {
     windowSettingsContainer.classList.add("bonkhud-border-color");
     windowSettingsContainer.classList.add("bonkhud-scrollbar-kit");
     windowSettingsContainer.classList.add("bonkhud-scrollbar-other");
-    windowSettingsContainer.style.flexGrow = "1.5";
+    windowSettingsContainer.style.width = "35%";
     windowSettingsContainer.style.overflowY = "scroll";
     windowSettingsContainer.style.height = "100%";
     windowSettingsContainer.style.borderRight = "1px solid";
@@ -65,9 +65,12 @@ bonkHUD.initialize = function () {
     settingsContainer.classList.add("bonkhud-scrollbar-other");
     settingsContainer.id = "bonkhud-settings-container";
     settingsContainer.style.overflowY = "scroll";
-    settingsContainer.style.flexGrow = "3";
+    settingsContainer.style.width = "65%";
     settingsContainer.style.float = "right";
     settingsContainer.style.height = "100%";
+
+    // Create holder for mainSettings and styleSettings
+    let generalSettingsDiv = document.createElement("div");
 
     let mainSettingsDiv = document.createElement("div");
     mainSettingsDiv.classList.add("bonkhud-border-color")
@@ -75,9 +78,19 @@ bonkHUD.initialize = function () {
 
     let mainSettingsHeading = document.createElement("div");
     mainSettingsHeading.classList.add("bonkhud-text-color");
-    mainSettingsHeading.textContent = "General Settings";
-    mainSettingsHeading.style.marginBottom = "5px";
     mainSettingsHeading.style.fontSize = "1.2rem";
+    mainSettingsHeading.style.marginBottom = "5px";
+    mainSettingsHeading.textContent = "Main Settings";
+
+    let mainSettingsAdHideLabel = document.createElement("label");
+    mainSettingsAdHideLabel.classList.add("bonkhud-text-color");
+    mainSettingsAdHideLabel.classList.add("bonkhud-settings-label");
+    mainSettingsAdHideLabel.style.marginRight = "5px";
+    mainSettingsAdHideLabel.innerText = "Hide Ads";
+
+    let mainSettingsAdHide = document.createElement("input");
+    mainSettingsAdHide.type = "checkbox";
+    mainSettingsAdHide.checked = false;
 
     let styleResetDiv = document.createElement("div");
     styleResetDiv.style.marginTop = "5px";
@@ -138,6 +151,10 @@ bonkHUD.initialize = function () {
     styleSettingsHeading.style.marginBottom = "5px";
     styleSettingsHeading.textContent = "Style Settings";
 
+    mainSettingsDiv.appendChild(mainSettingsHeading);
+    mainSettingsDiv.appendChild(mainSettingsAdHideLabel);
+    mainSettingsDiv.appendChild(mainSettingsAdHide);
+
     // Append children of style settings to rows
     styleResetDiv.appendChild(styleResetLabel);
     styleResetDiv.appendChild(styleResetButton);
@@ -151,6 +168,28 @@ bonkHUD.initialize = function () {
     styleSettingsDiv.appendChild(styleResetDiv);
     styleSettingsDiv.appendChild(styleExportDiv)
     styleSettingsDiv.appendChild(styleImportDiv);
+
+    let holdLeft = document.createElement("div");
+    holdLeft.style.display = "flex";
+    holdLeft.style.alignContent = "center";
+
+    let opacityLabel = document.createElement("label");
+    opacityLabel.classList.add("bonkhud-settings-label");
+    opacityLabel.textContent = "Opacity";
+
+    let opacitySlider = document.createElement("input");
+    opacitySlider.type = "range"; // Slider type for range selection
+    opacitySlider.min = "0.1"; // Minimum opacity value
+    opacitySlider.max = "1"; // Maximum opacity value (fully opaque)
+    opacitySlider.step = "0.05"; // Incremental steps for opacity adjustment
+    opacitySlider.value = "1"; // Default value set to fully opaque
+    opacitySlider.style.minWidth = "20px";
+    opacitySlider.style.flexGrow = "1"; // Width adjusted for the label
+
+    holdLeft.appendChild(opacityLabel);
+    holdLeft.appendChild(opacitySlider);
+
+    styleSettingsDiv.appendChild(holdLeft);
 
     for (let prop in bonkHUD.styleHold) {
         let colorDiv = document.createElement("div");
@@ -205,14 +244,6 @@ bonkHUD.initialize = function () {
     header.appendChild(title);
     header.appendChild(closeButton)
 
-    // Append children of general settings to rows
-    //? not appending mainSettingsDiv since there is nothing to put in it yet
-    //mainSettingsDiv.appendChild(mainSettingsHeading);
-
-    // Append general setting rows to general settings container
-    //settingsContainer.appendChild(mainSettingsDiv);
-    settingsContainer.appendChild(styleSettingsDiv);
-
     // Append everything to main container (HUD window)
     containerContainer.appendChild(windowSettingsContainer);
     containerContainer.appendChild(settingsContainer);
@@ -224,6 +255,53 @@ bonkHUD.initialize = function () {
     document.getElementById('prettymenu').appendChild(settingsMenu);
     //Place it before help button
     document.getElementById('pretty_top_bar').appendChild(topBarOption);
+
+    // Add settings
+    bonkHUD.createSettingsControl(mainSettingsDiv, generalSettingsDiv);
+    bonkHUD.createSettingsControl(styleSettingsDiv, generalSettingsDiv);
+    bonkHUD.createMenuHeader("General", generalSettingsDiv);
+
+    let ind = bonkHUD.settingsHold.length;
+    bonkHUD.settingsHold.push("bonkhud-main-mod-setting");
+    let settings = { hideAds: false, opacity: "1"};
+    let tempSettings = bonkHUD.getModSetting(ind);
+    if (tempSettings != null) {
+        settings = tempSettings;
+        // Could bring into one function then call it
+        mainSettingsAdHide.checked = settings.hideAds;
+        let ad1 = window.top.document.getElementById('adboxverticalCurse');
+        let ad2 = window.top.document.getElementById('adboxverticalleftCurse');
+        if (settings.hideAds) {
+            ad1.style.display = "none";
+            ad2.style.display = "none";
+        } else {
+            ad1.style.display = "block";
+            ad2.style.display = "block";
+        }
+
+        opacitySlider.value = settings.opacity;
+        settingsMenu.style.opacity = settings.opacity;
+    }
+
+    opacitySlider.oninput = function () {
+        settingsMenu.style.opacity = this.value;
+        settings.opacity = this.value;
+        bonkHUD.saveModSetting(ind, settings);
+    };
+
+    mainSettingsAdHide.oninput = function () {
+        settings.hideAds = this.checked;
+        let ad1 = window.top.document.getElementById('adboxverticalCurse');
+        let ad2 = window.top.document.getElementById('adboxverticalleftCurse');
+        if (settings.hideAds) {
+            ad1.style.display = "none";
+            ad2.style.display = "none";
+        } else {
+            ad1.style.display = "block";
+            ad2.style.display = "block";
+        }
+        bonkHUD.saveModSetting(ind, settings);
+    }
 
     // Make menu to control opacity + visibility visible
     closeButton.addEventListener('click', (e) => {

--- a/src/BonkHUD/loadInitialization.js
+++ b/src/BonkHUD/loadInitialization.js
@@ -3,10 +3,3 @@
 bonkHUD.loadStyleSettings();
 bonkHUD.initialize();
 bonkHUD.updateStyleSettings();
-
-
-//!implement later on a toggle to show or hide ads
-let ad1 = window.top.document.getElementById('adboxverticalCurse');
-let ad2 = window.top.document.getElementById('adboxverticalleftCurse');
-ad1.style.display = "none";
-ad2.style.display = "none";

--- a/src/BonkHUD/preloadVars.js
+++ b/src/BonkHUD/preloadVars.js
@@ -2,6 +2,7 @@
 window.bonkHUD = {};
 
 bonkHUD.windowHold = [];
+bonkHUD.settingsHold = [];
 
 //! not used but will be
 // *Style Store

--- a/src/BonkHUD/windowControl.js
+++ b/src/BonkHUD/windowControl.js
@@ -1,21 +1,46 @@
 //@Main{Preload}
 
-bonkHUD.createMenuHeader = function (name, recVersion) {
+bonkHUD.createMenuHeader = function (name, settingsContent, recVersion = -1) {
     // Create container for the opacity controls with initial styles
     let sliderRow = bonkHUD.generateSection();
 
     // Add a title to the slider row for visual clarity
     let sliderTitle = document.createElement("div");
-    sliderTitle.textContent = name + " ("+recVersion+")";
+    if (recVersion === -1) {
+        sliderTitle.textContent = name;
+    } else {
+        sliderTitle.textContent = name + " ("+recVersion+")";
+    }
     sliderTitle.style.marginBottom = "5px";
     sliderTitle.style.fontSize = "1.2rem"; // Text size for readability
     sliderTitle.style.fontWeight = "bold"; // Make the title text bold
     sliderRow.appendChild(sliderTitle); // Insert the title into the slider container
 
+    //open settings in
+    settingsContent.prepend(sliderRow.cloneNode(true));
+    settingsContent.classList.add("bonkhud-mod-setting-menu");
+    settingsContent.style.display = "none";
+    document.getElementById("bonkhud-settings-container").appendChild(settingsContent);
+
+    sliderRow.addEventListener("click", (e) => {
+        let menus = document.getElementsByClassName("bonkhud-mod-setting-menu");
+        // Could make this without for loop but would need to store last menu
+        for (let i = 0; i < menus.length; i++) {
+            menus[i].style.display = "none";
+        }
+        settingsContent.style.display = "block";
+
+        let titles = document.getElementById("bonkhud-window-settings-container").children;
+        for (let i = 0; i < titles.length; i++) {
+            titles[i].children[0].style.color = bonkHUD.styleHold.textColor.color;
+        }
+        sliderTitle.style.color = bonkHUD.styleHold.secondaryTextColor.color;
+    });
+
     document.getElementById("bonkhud-window-settings-container").appendChild(sliderRow);
 }
 
-bonkHUD.createWindowControl = function (ind) {
+bonkHUD.createWindowControl = function (ind, element) {
     let sliderRow = bonkHUD.generateSection();
 
     let holdLeft = document.createElement("div");
@@ -86,7 +111,8 @@ bonkHUD.createWindowControl = function (ind) {
     sliderRow.appendChild(holdRight);
     sliderRow.appendChild(windowResetButton);
 
-    bonkHUD.settingsHold[ind].settings.appendChild(sliderRow);
+    element.appendChild(sliderRow);
+    //bonkHUD.settingsHold[ind].settings.appendChild(sliderRow);
 };
 
 bonkHUD.focusWindow = function (focusItem) {

--- a/src/BonkHUD/windowControl.js
+++ b/src/BonkHUD/windowControl.js
@@ -37,7 +37,7 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
         let control = document.getElementById(bonkHUD.windowHold[ind].id + "-drag"); // Update the UI opacity in real-time;
         control.style.opacity = this.value;
         bonkHUD.windowHold[ind].opacity = control.style.opacity;
-        bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+        bonkHUD.saveUISetting(ind);
     };
     holdLeft.appendChild(opacitySlider); // Place the slider into the slider container
 
@@ -65,7 +65,7 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
         let control = document.getElementById(bonkHUD.windowHold[ind].id + "-drag"); // Update the UI opacity in real-time;
         control.style.display = this.checked ? "block" : "none";
         bonkHUD.windowHold[ind].display = control.style.display;
-        bonkHUD.saveUISetting(bonkHUD.windowHold[ind].id);
+        bonkHUD.saveUISetting(ind);
     };
     holdRight.appendChild(visiblityCheck); // Place the slider into the slider container
 

--- a/src/BonkHUD/windowControl.js
+++ b/src/BonkHUD/windowControl.js
@@ -1,10 +1,8 @@
 //@Main{Preload}
 
-bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement = 0) {
+bonkHUD.createMenuHeader = function (name, recVersion) {
     // Create container for the opacity controls with initial styles
-    let sliderRow = document.createElement("div");
-    sliderRow.classList.add("bonkhud-settings-row");
-    sliderRow.classList.add("bonkhud-border-color");
+    let sliderRow = bonkHUD.generateSection();
 
     // Add a title to the slider row for visual clarity
     let sliderTitle = document.createElement("div");
@@ -13,6 +11,12 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
     sliderTitle.style.fontSize = "1.2rem"; // Text size for readability
     sliderTitle.style.fontWeight = "bold"; // Make the title text bold
     sliderRow.appendChild(sliderTitle); // Insert the title into the slider container
+
+    document.getElementById("bonkhud-window-settings-container").appendChild(sliderRow);
+}
+
+bonkHUD.createWindowControl = function (ind) {
+    let sliderRow = bonkHUD.generateSection();
 
     let holdLeft = document.createElement("div");
     holdLeft.style.display = "flex";
@@ -82,12 +86,7 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
     sliderRow.appendChild(holdRight);
     sliderRow.appendChild(windowResetButton);
 
-    //! may instead make it so when sliderrow is focused, the
-    //! seetings appear on the big settings menu
-    if(settingsElement !== 0 && settingsElement instanceof Node)
-        sliderRow.appendChild(settingsElement);
-
-    return sliderRow; // Return the fully constructed slider row element
+    bonkHUD.settingsHold[ind].settings.appendChild(sliderRow);
 };
 
 bonkHUD.focusWindow = function (focusItem) {

--- a/src/BonkHUD/windowControl.js
+++ b/src/BonkHUD/windowControl.js
@@ -74,8 +74,8 @@ bonkHUD.createWindowControl = function (name, recVersion, ind, settingsElement =
     windowResetButton.style.paddingRight = "5px";
     windowResetButton.style.display = "inline-block";
     windowResetButton.addEventListener('click', (e) => {
-        bonkHUD.resetUISetting(bonkHUD.windowHold[ind].id);
-        bonkHUD.loadUISetting(bonkHUD.windowHold[ind].id);
+        bonkHUD.resetUISetting(ind);
+        bonkHUD.loadUISetting(ind);
     });
 
     sliderRow.appendChild(holdLeft);


### PR DESCRIPTION
Mostly the same as v1.1.1 but createWindow / createMod now return the index instead of the window content. This is to let someone creating a windowless mod access saving settings of mods without explicitly making an id (although any bonkHUD method that needs the index must be called/defined after createWindow / createMod have been called which makes it less straightforward to create settings).

** If you dont want a settings gui either, you can directly push an id to bonkHUD.settingsHold and use that index to save and load settings without breaking anything **