### PR TITLE
1.1.5 fix mod crash

### DIFF
--- a/UserScript/BonkLIB.user.js
+++ b/UserScript/BonkLIB.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         BonkLIB
-// @version      1.1.4
+// @version      1.1.5
 // @author       FeiFei + Clarifi + BoZhi
 // @namespace    https://github.com/FeiFei-GH/BonkLIB
 // @description  BonkAPI + BonkHUD
@@ -16,7 +16,7 @@ https://greasyfork.org/en/scripts/433861-code-injector-bonk-io
 
 // ! Compitable with Bonk Version 49
 window.bonkLIB = {};
-bonkLIB.version = "1.1.4";
+bonkLIB.version = "1.1.5";
 
 
 window.bonkAPI = {};

--- a/UserScript/BonkLIB.user.js
+++ b/UserScript/BonkLIB.user.js
@@ -2051,8 +2051,8 @@ bonkHUD.createMod = function (modName, opts = {}) {
         if(opts.bonkLIBVersion != bonkLIB.version) {
             if(typeof opts.bonkLIBVersion === 'string') {
                 if(opts.bonkLIBVersion.substring(0, opts.bonkLIBVersion.lastIndexOf(".")) != bonkLIB.version.substring(0, bonkLIB.version.lastIndexOf(".")))
-                    alert(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
-                console.log(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+                    alert(modName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+                console.log(modName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
             }
             else {
                 alert("Version is incompatible, please check with mod maker to fix");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bonklib",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bonklib",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "license": "MIT",
             "dependencies": {
                 "bonklib": "file:",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bonklib",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "BonkLIB",
     "main": "index.js",
     "scripts": {

--- a/src/BonkHUD/createWindow.js
+++ b/src/BonkHUD/createWindow.js
@@ -182,8 +182,8 @@ bonkHUD.createMod = function (modName, opts = {}) {
         if(opts.bonkLIBVersion != bonkLIB.version) {
             if(typeof opts.bonkLIBVersion === 'string') {
                 if(opts.bonkLIBVersion.substring(0, opts.bonkLIBVersion.lastIndexOf(".")) != bonkLIB.version.substring(0, bonkLIB.version.lastIndexOf(".")))
-                    alert(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
-                console.log(windowName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+                    alert(modName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
+                console.log(modName + " may not be compatible with current version of BonkLIB ("+opts.bonkLIBVersion+" =/= "+bonkLIB.version+")");
             }
             else {
                 alert("Version is incompatible, please check with mod maker to fix");


### PR DESCRIPTION
This pull request updates the BonkLIB version to 1.1.5 and improves the compatibility warning messages in both the user script and source code. The main focus is to ensure that mod compatibility alerts reference the correct mod name rather than a window name, providing clearer feedback to users and developers.

Version update:

* Bumped the BonkLIB version from 1.1.4 to 1.1.5 in `UserScript/BonkLIB.user.js` and `package.json` to reflect the new release. [[1]](diffhunk://#diff-26e322c3dfdb22cb73544b537da9f08a3eda1b01904e1c2064526a96e89d7a57L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-26e322c3dfdb22cb73544b537da9f08a3eda1b01904e1c2064526a96e89d7a57L19-R19)

User experience improvements:

* Updated compatibility warning messages in both `UserScript/BonkLIB.user.js` and `src/BonkHUD/createWindow.js` so that alerts and logs now reference the `modName` instead of `windowName`, making it clearer which mod may have compatibility issues. [[1]](diffhunk://#diff-26e322c3dfdb22cb73544b537da9f08a3eda1b01904e1c2064526a96e89d7a57L2054-R2055) [[2]](diffhunk://#diff-0c85e906c6e70664d0bf9b7cfab51b45d51e3dd6bda42a3296b9d88d60b771d1L185-R186)